### PR TITLE
Add missing double type

### DIFF
--- a/docs/source/_ext/lexers.py
+++ b/docs/source/_ext/lexers.py
@@ -405,6 +405,7 @@ cython_tokens["builtins"][
             "dict",
             "dir",
             "divmod",
+            "double",  # added
             "enumerate",
             "eval",
             "execfile",


### PR DESCRIPTION
feat(_ext.lexers): Include missing double type in builtin words for cython lexer.